### PR TITLE
Add deprecate wording about the Dynatrace metrics exporter

### DIFF
--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -132,8 +132,8 @@ service:
 
 ## Dynatrace
 
-Dynatrace supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
-can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or non-OTLP exporters.
+[Dynatrace](https://www.dynatrace.com/integrations/opentelemetry) supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
+can send traces, metrics and logs directly to Dynatrace without the need for additional plugins or exporters.
 
 <SubSectionSeparator />
 
@@ -149,7 +149,7 @@ can send traces, metrics and logs directly to Dynatrace without the need of addi
 - Dynatrace 1.254 or later
 - An API token with the **Ingest metrics** scope
 - Delta metrics: Dynatrace only supports ingesting metrics with delta aggregation temporality. 
-  To learn more about aggregation temporality and how to configure your applications and collector, see the 
+  To learn more about aggregation temporality and how to configure your applications or collectors, see the 
   [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/migrating-dynatrace-metrics-exporter-otlp-exporter#make-sure-metrics-have-delta-aggregation-temporality).
 
 #### OTLP Logs Ingest

--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -132,8 +132,8 @@ service:
 
 ## Dynatrace
 
-Dynatrace supports OpenTelemetry by ingesting OTLP directly, so users of the AWS Distro for OpenTelemetry (ADOT) can send tracing data directly to 
-Dynatrace without the need for additional plugins or non-OTLP exporters.
+Dynatrace supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
+can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or non-OTLP exporters.
 
 <SubSectionSeparator />
 
@@ -148,6 +148,14 @@ Dynatrace without the need for additional plugins or non-OTLP exporters.
 
 - Dynatrace 1.254 or later
 - An API token with the **Ingest metrics** scope
+- Delta metrics: Dynatrace only supports ingesting metrics with delta aggregation temporality. 
+  To learn more about aggregation temporality and how to configure your applications and collector, see the 
+  [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/migrating-dynatrace-metrics-exporter-otlp-exporter#make-sure-metrics-have-delta-aggregation-temporality).
+
+#### OTLP Logs Ingest
+
+- Dynatrace 1.269 or later
+- An API token with the **Ingest logs** scope
 
 <SubSectionSeparator />
 
@@ -189,6 +197,10 @@ service:
       processors: []
       exporters: [otlphttp]
     metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+    logs:
       receivers: [otlp]
       processors: []
       exporters: [otlphttp]

--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -149,7 +149,7 @@ can send traces, metrics and logs directly to Dynatrace without the need for add
 - Dynatrace 1.254 or later
 - An API token with the **Ingest metrics** scope
 - Delta metrics: Dynatrace only supports ingesting metrics with delta aggregation temporality. 
-  To learn more about aggregation temporality and how to configure your applications or collectors, see the 
+  To learn more about aggregation temporality and how to configure your applications or collectors, please refer to the 
   [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/migrating-dynatrace-metrics-exporter-otlp-exporter#make-sure-metrics-have-delta-aggregation-temporality).
 
 #### OTLP Logs Ingest

--- a/src/docs/partners/dynatrace.mdx
+++ b/src/docs/partners/dynatrace.mdx
@@ -6,12 +6,12 @@ description:
 path: '/docs/partners/dynatrace'
 ---
 
-Dynatrace supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
-can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or non-OTLP exporters.
+[Dynatrace](https://www.dynatrace.com/integrations/opentelemetry) supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
+can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or exporters.
 See the [OTLP documentation](/docs/components/otlp-exporter#dynatrace) for configuration examples. More information on using the collector with Dynatrace can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-collector-explanation).
 
-The Dynatrace OpenTelemetry metrics exporter is deprecated.
+The proprietary Dynatrace OpenTelemetry metrics exporter is deprecated in favor of exporting via OTLP.
 The rest of this page covers the documentation of this deprecated exporter.
 
 # Dynatrace OpenTelemetry metrics exporter (deprecated)

--- a/src/docs/partners/dynatrace.mdx
+++ b/src/docs/partners/dynatrace.mdx
@@ -5,25 +5,22 @@ description:
     and observability across your full stack.
 path: '/docs/partners/dynatrace'
 ---
-## Overview
 
-[Dynatrace](https://www.dynatrace.com/integrations/opentelemetry/) is an all-in-one software intelligence platform delivering continuous, automatic discovery and observability across your full stack.
+Dynatrace supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
+can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or non-OTLP exporters.
+See the [OTLP documentation](/docs/components/otlp-exporter#dynatrace) for configuration examples. More information on using the collector with Dynatrace can be found in the
+[Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-collector-explanation).
 
-For ingesting traces (spans) into Dynatrace, use the generic OTLP/HTTP exporter shipped with the Collector.  
-More information on exporting traces to Dynatrace can be found in the
-[Dynatrace documentation for OpenTelemetry traces](https://www.dynatrace.com/support/help/extend-dynatrace/opentelemetry/opentelemetry-traces/opentelemetry-ingest).
+The Dynatrace OpenTelemetry metrics exporter is deprecated.
+The rest of this page covers the documentation of this deprecated exporter.
 
-OpenTelemetry metrics can be exported to Dynatrace in the following ways:
+# Dynatrace OpenTelemetry metrics exporter (deprecated)
 
-- Using OTLP/HTTP (OpenTelemetry Protocol) metrics exporter (recommended) - See [documentation](/docs/components/otlp-exporter#dynatrace)
-- Using Dynatrace OpenTelemetry metrics exporter described below
-
-More information on exporting metrics to Dynatrace can be found in the
-[Dynatrace documentation for OpenTelemetry metrics](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).
-
-The Dynatrace Open Source Engineering team developed this exporter for metrics in the OpenTelemetry Collector.
-The Dynatrace metrics exporter exports metrics to the [metrics API v2](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/post-ingest-metrics/) using the [metrics ingestion protocol](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/metric-ingestion-protocol/).
-This enables Dynatrace to receive, store, view, and analyze metrics collected by the OpenTelemetry Collector.
+> Dynatrace supports native OpenTelemetry protocol (OTLP) metrics ingest.
+> Since the OpenTelemetry Collector offers an OTLP exporter, the Dynatrace OpenTelemetry metrics exporter is now obsolete and no longer recommended.
+>
+> Check out the [migration guide](https://www.dynatrace.com/support/help/shortlink/migrating-dynatrace-metrics-exporter-otlp-exporter) on the Dynatrace documentation to learn how to migrate to the OTLP HTTP exporter.
+> See the [OTLP documentation](/docs/components/otlp-exporter#dynatrace) for a configuration example.
 
 ## Requirements
 

--- a/src/docs/partners/dynatrace.mdx
+++ b/src/docs/partners/dynatrace.mdx
@@ -7,7 +7,7 @@ path: '/docs/partners/dynatrace'
 ---
 
 [Dynatrace](https://www.dynatrace.com/integrations/opentelemetry) supports native OpenTelemetry protocol (OTLP) ingest, so users of the AWS Distro for OpenTelemetry (ADOT) 
-can send traces, metrics and logs directly to Dynatrace without the need of additional plugins or exporters.
+can send traces, metrics and logs directly to Dynatrace without the need for additional plugins or exporters.
 See the [OTLP documentation](/docs/components/otlp-exporter#dynatrace) for configuration examples. More information on using the collector with Dynatrace can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-collector-explanation).
 


### PR DESCRIPTION
- Consolidate the page stating Dynatrace supports all signals via OTLP
- Make it clear that the Dynatrace metrics exporter is deprecated (still keep the page as is, as existing users might still look for the documentation)
- Adapt the OTLP documentation on Dynatrace, to include OTLP logs and a note about aggregation temporality (links to the migration guide where we tell how they can configure things)
- Removed some text that we thought were not relevant/not adding anything to the page